### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,14 +3,14 @@
         {
             "type": "aws-sam",
             "request": "direct-invoke",
-            "name": "functions:StatusCheck:app.lambdaHandler (nodejs14.x)",
+            "name": "functions:StatusCheck:app.lambdaHandler (nodejs16.x)",
             "invokeTarget": {
                 "target": "code",
                 "projectRoot": "${workspaceFolder}/src/functions/StatusCheck",
                 "lambdaHandler": "app.lambdaHandler"
             },
             "lambda": {
-                "runtime": "nodejs14.x",
+                "runtime": "nodejs16.x",
                 "payload": {
                 "path": "${workspaceFolder}/events/status-check-payload.json"
                 },
@@ -34,14 +34,14 @@
         {
             "type": "aws-sam",
             "request": "direct-invoke",
-            "name": "functions:app.lambdaHandler (nodejs14.x)",
+            "name": "functions:app.lambdaHandler (nodejs16.x)",
             "invokeTarget": {
                 "target": "code",
                 "projectRoot": "${workspaceFolder}/src/functions/BookHotel",
                 "lambdaHandler": "app.lambdaHandler"
             },
             "lambda": {
-                "runtime": "nodejs14.x",
+                "runtime": "nodejs16.x",
                 "payload": {},
                 "environmentVariables": {}
             }
@@ -49,14 +49,14 @@
         {
             "type": "aws-sam",
             "request": "direct-invoke",
-            "name": "functions:bookCar.app.lambdaHandler (nodejs14.x)",
+            "name": "functions:bookCar.app.lambdaHandler (nodejs16.x)",
             "invokeTarget": {
                 "target": "code",
                 "projectRoot": "${workspaceFolder}/src/functions/BookCar",
                 "lambdaHandler": "app.lambdaHandler"
             },
             "lambda": {
-                "runtime": "nodejs14.x",
+                "runtime": "nodejs16.x",
                 "payload": {
                     "json": {
                         "failBookCar": true

--- a/launch.json
+++ b/launch.json
@@ -3,14 +3,14 @@
         {
             "type": "aws-sam",
             "request": "direct-invoke",
-            "name": "functions:StatusCheck:app.lambdaHandler (nodejs14.x)",
+            "name": "functions:StatusCheck:app.lambdaHandler (nodejs16.x)",
             "invokeTarget": {
                 "target": "code",
                 "projectRoot": "${workspaceFolder}/src/functions/StatusCheck",
                 "lambdaHandler": "app.lambdaHandler"
             },
             "lambda": {
-                "runtime": "nodejs14.x",
+                "runtime": "nodejs16.x",
                 "payload": {
                 "path": "${workspaceFolder}/events/status-check-payload.json"
                 },
@@ -34,14 +34,14 @@
         {
             "type": "aws-sam",
             "request": "direct-invoke",
-            "name": "functions:app.lambdaHandler (nodejs14.x)",
+            "name": "functions:app.lambdaHandler (nodejs16.x)",
             "invokeTarget": {
                 "target": "code",
                 "projectRoot": "${workspaceFolder}/src/functions/BookHotel",
                 "lambdaHandler": "app.lambdaHandler"
             },
             "lambda": {
-                "runtime": "nodejs14.x",
+                "runtime": "nodejs16.x",
                 "payload": {},
                 "environmentVariables": {}
             }
@@ -49,14 +49,14 @@
         {
             "type": "aws-sam",
             "request": "direct-invoke",
-            "name": "functions:bookCar.app.lambdaHandler (nodejs14.x)",
+            "name": "functions:bookCar.app.lambdaHandler (nodejs16.x)",
             "invokeTarget": {
                 "target": "code",
                 "projectRoot": "${workspaceFolder}/src/functions/BookCar",
                 "lambdaHandler": "app.lambdaHandler"
             },
             "lambda": {
-                "runtime": "nodejs14.x",
+                "runtime": "nodejs16.x",
                 "payload": {
                     "json": {
                         "failBookCar": true

--- a/template.yml
+++ b/template.yml
@@ -23,7 +23,7 @@ Globals:
   Function:
     Tracing: Active
     Handler: app.lambdaHandler
-    Runtime: nodejs14.x
+    Runtime: nodejs16.x
     MemorySize: 128
     Timeout: 200
 


### PR DESCRIPTION
CloudFormation templates in aws-step-functions-saga-pattern-with-sam have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.